### PR TITLE
Indicue: Set GVL vendor ID to 0

### DIFF
--- a/static/bidder-info/indicue.yaml
+++ b/static/bidder-info/indicue.yaml
@@ -2,7 +2,7 @@ aliasOf: adtelligent
 endpoint: "http://ghb.console.indicue.com/pbs/ortb"
 maintainer:
   email: "ops@indicue.com"
-gvlVendorID: 410
+gvlVendorID: 0
 userSync:
   # Indicue ssp supports user syncing, but requires configuration by the host. contact this
   # bidder directly at the email address in this file to ask about enabling user sync.


### PR DESCRIPTION
## Summary
- Sets indicue adapter GVL vendor ID to 0, removing the inherited value from the parent (adtelligent) adapter.

This follows the approach in #4683 for aliases that don't have a confirmed explicit GVL ID.